### PR TITLE
Feat: Add footer navigation and sroll position cache

### DIFF
--- a/duoclone-root/duolingo-clone/src/App.tsx
+++ b/duoclone-root/duolingo-clone/src/App.tsx
@@ -3,13 +3,19 @@ import { SectionPage } from "./features/Section/SectionPage";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { LessonPage } from "./features/Lesson/LessonPage";
 import { LessonCompletePage } from "./features/Lesson/LessonCompletePage";
+import { QuestsPage } from "./features/Quests/QuestsPage";
+import { MainLayout } from "./components/layouts/MainLayout";
 
 function App() {
   return (
     <Router>
       <div className="w-dvw h-dvh flex flex-col overflow-auto bg-duoBackground">
         <Routes>
-          <Route path="" element={<SectionPage />} />
+          <Route element={<MainLayout />}>
+            <Route path="" element={<SectionPage />} />
+            <Route path="/quests" element={<QuestsPage />} />
+          </Route>
+
           <Route path="/lessons/:lessonId/:position" element={<LessonPage />} />
           <Route
             path="/lessons/:lessonId/complete"

--- a/duoclone-root/duolingo-clone/src/components/layouts/MainLayout.tsx
+++ b/duoclone-root/duolingo-clone/src/components/layouts/MainLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router";
+import { MainFooter } from "../../features/Common/MainFooter";
+
+export function MainLayout() {
+  return (
+    <>
+      <Outlet />
+      <MainFooter />
+    </>
+  );
+}

--- a/duoclone-root/duolingo-clone/src/components/molecules/Footer/FooterButton.tsx
+++ b/duoclone-root/duolingo-clone/src/components/molecules/Footer/FooterButton.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react"
+import { useNavigate } from "react-router";
+
+type FooterButtonProps = {
+    children: React.ReactNode;
+    path: string;
+}
+
+export function FooterButton ({children, path}: FooterButtonProps) {
+
+    const navigate = useNavigate();
+
+    const handleNavigation = () => {
+        if (path.length > 0) {
+            navigate(path);
+        }
+    }
+
+    return (
+        <div onClick={() => handleNavigation()}>
+            {children}
+        </div>
+    )
+
+}

--- a/duoclone-root/duolingo-clone/src/components/molecules/Footer/FooterButton.tsx
+++ b/duoclone-root/duolingo-clone/src/components/molecules/Footer/FooterButton.tsx
@@ -1,25 +1,26 @@
-import type { ReactNode } from "react"
-import { useNavigate } from "react-router";
+import type { ReactNode } from "react";
+import { useLocation, useNavigate } from "react-router";
 
 type FooterButtonProps = {
-    children: React.ReactNode;
-    path: string;
-}
+  children: React.ReactNode;
+  path: string;
+};
 
-export function FooterButton ({children, path}: FooterButtonProps) {
+export function FooterButton({ children, path }: FooterButtonProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    const navigate = useNavigate();
+  const isActive =
+    path === "/" ? location.pathname === "/" : location.pathname.includes(path);
 
-    const handleNavigation = () => {
-        if (path.length > 0) {
-            navigate(path);
-        }
+  const style = isActive ? "border border-duoBlue/80 bg-duoBlue/8" : "";
+  const baseStyle = "p-2 rounded-lg"
+
+  const handleNavigation = () => {
+    if (path.length > 0) {
+      navigate(path);
     }
+  };
 
-    return (
-        <div onClick={() => handleNavigation()}>
-            {children}
-        </div>
-    )
-
+  return <div className={`${baseStyle} ${style}`} onClick={() => handleNavigation()}>{children}</div>;
 }

--- a/duoclone-root/duolingo-clone/src/features/Common/MainFooter.tsx
+++ b/duoclone-root/duolingo-clone/src/features/Common/MainFooter.tsx
@@ -16,15 +16,15 @@ export function MainFooter() {
         <FooterButton path="/">
           <UserHomeIcon />
         </FooterButton>
-        <div>
+        <FooterButton path="/league">
           <UserLeagueIcon />
-        </div>
+        </FooterButton>
         <FooterButton path="/quests">
           <UserChestQuestsIcon />
         </FooterButton>
-        <div>
+        <FooterButton path="/user">
           <UserFooterIcon />
-        </div>
+        </FooterButton>
       </div>
     </Footer>
   );

--- a/duoclone-root/duolingo-clone/src/features/Common/MainFooter.tsx
+++ b/duoclone-root/duolingo-clone/src/features/Common/MainFooter.tsx
@@ -1,18 +1,30 @@
+import { useNavigate } from "react-router";
 import { UserChestQuestsIcon } from "../../components/atoms/Icons/UserChestQuestsIcon";
 import { UserFooterIcon } from "../../components/atoms/Icons/UserFooterIcon";
 import { UserHomeIcon } from "../../components/atoms/Icons/UserHomeIcon";
 import { UserLeagueIcon } from "../../components/atoms/Icons/UserLeagueIcon";
 import { UserPracticeIcon } from "../../components/atoms/Icons/UserPracticeIcon";
 import { Footer } from "../../components/molecules/Footer/Footer";
+import { FooterButton } from "../../components/molecules/Footer/FooterButton";
 
 export function MainFooter() {
+  const navigate = useNavigate();
+
   return (
     <Footer padding="px-6" height="h-20 border-t border-t-duoGrayBorder">
       <div className="w-full flex items-center justify-between">
-        <UserHomeIcon />
-        <UserLeagueIcon />
-        <UserChestQuestsIcon />
-        <UserFooterIcon />
+        <FooterButton path="/">
+          <UserHomeIcon />
+        </FooterButton>
+        <div>
+          <UserLeagueIcon />
+        </div>
+        <FooterButton path="/quests">
+          <UserChestQuestsIcon />
+        </FooterButton>
+        <div>
+          <UserFooterIcon />
+        </div>
       </div>
     </Footer>
   );

--- a/duoclone-root/duolingo-clone/src/features/Section/SectionPage.tsx
+++ b/duoclone-root/duolingo-clone/src/features/Section/SectionPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LearnHeader } from "./LearnHeader";
 import { UnitBanner } from "../Unit/UnitBanner";
 import { UnitPath } from "../Unit/UnitPath";
@@ -9,10 +9,9 @@ import {
 } from "../../queries/useQuery/useSectionTree";
 import { useCourseProgress } from "../../queries/useQuery/useCourseProgress";
 import { SpinnerPage } from "./SpinnerPage";
-import { MainFooter } from "../Common/MainFooter";
-import type { UnitType } from "../../Types/UnitType";
 import { useCurrentUser } from "../../queries/useQuery/useCurrentUser";
 import { useCurrentUnitStore } from "../../queries/useQuery/useCurrentUnitStore";
+import { scrollToUnit } from "../../util/scrollUtils";
 
 export function SectionPage() {
   const { isLoading, isError } = useSectionTree(1);
@@ -22,19 +21,27 @@ export function SectionPage() {
 
   const { currentUnit, setCurrentUnit } = useCurrentUnitStore();
   const unitRefs = useRef<(HTMLElement | null)[]>([]);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { data: currentUser, isLoading: loadingUser } = useCurrentUser(1);
 
-  const {data: currentUser, isLoading: loadingUser} = useCurrentUser(1);
+  useEffect(() => {
+    scrollToUnit(currentUnit, units, scrollContainerRef, unitRefs);
+  }, []);
 
   useUnitObserver(unitRefs, units ?? [], setCurrentUnit);
 
   if (isError) return <SpinnerPage color="border-red-400" />;
-  if (loadingUser || isLoading || !units || !courseProgress) return <SpinnerPage />;
+  if (loadingUser || isLoading || !units || !courseProgress)
+    return <SpinnerPage />;
 
   return (
     <>
       <LearnHeader courseProgress={courseProgress} />
       <UnitBanner currentUnit={currentUnit} />
-      <div className="w-full h-full mb-10 overflow-auto">
+      <div
+        ref={scrollContainerRef}
+        className="w-full h-full mb-10 overflow-auto"
+      >
         {units.map((unit, index) => (
           <div
             key={unit.id}

--- a/duoclone-root/duolingo-clone/src/features/Section/SectionPage.tsx
+++ b/duoclone-root/duolingo-clone/src/features/Section/SectionPage.tsx
@@ -12,6 +12,7 @@ import { SpinnerPage } from "./SpinnerPage";
 import { MainFooter } from "../Common/MainFooter";
 import type { UnitType } from "../../Types/UnitType";
 import { useCurrentUser } from "../../queries/useQuery/useCurrentUser";
+import { useCurrentUnitStore } from "../../queries/useQuery/useCurrentUnitStore";
 
 export function SectionPage() {
   const { isLoading, isError } = useSectionTree(1);
@@ -19,12 +20,12 @@ export function SectionPage() {
   const { data: courseProgress, isLoading: loadingProgress } =
     useCourseProgress(1, 1);
 
-  const [currentUnit, setCurrentUnit] = useState<UnitType | null>(null);
+  const { currentUnit, setCurrentUnit } = useCurrentUnitStore();
   const unitRefs = useRef<(HTMLElement | null)[]>([]);
 
   const {data: currentUser, isLoading: loadingUser} = useCurrentUser(1);
 
-useUnitObserver(unitRefs, units ?? [], (u) => setCurrentUnit(u));
+  useUnitObserver(unitRefs, units ?? [], setCurrentUnit);
 
   if (isError) return <SpinnerPage color="border-red-400" />;
   if (loadingUser || isLoading || !units || !courseProgress) return <SpinnerPage />;
@@ -45,7 +46,6 @@ useUnitObserver(unitRefs, units ?? [], (u) => setCurrentUnit(u));
           </div>
         ))}
       </div>
-      <MainFooter />
     </>
   );
 }

--- a/duoclone-root/duolingo-clone/src/queries/useQuery/useCurrentUnitStore.tsx
+++ b/duoclone-root/duolingo-clone/src/queries/useQuery/useCurrentUnitStore.tsx
@@ -1,0 +1,21 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UnitType } from '../../Types/UnitType';
+
+export function useCurrentUnitStore() {
+  const queryClient = useQueryClient();
+  const queryKey = ['currentUnit'];
+
+  const { data: currentUnit } = useQuery<UnitType | null>({
+    queryKey,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 5, // Changed from cacheTime to gcTime
+    queryFn: () => queryClient.getQueryData(queryKey) ?? null, // Added queryFn
+    initialData: null
+  });
+
+  const setCurrentUnit = (unit: UnitType) => {
+    queryClient.setQueryData(queryKey, unit);
+  };
+
+  return { currentUnit, setCurrentUnit };
+}

--- a/duoclone-root/duolingo-clone/src/queries/useQuery/useSectionTree.tsx
+++ b/duoclone-root/duolingo-clone/src/queries/useQuery/useSectionTree.tsx
@@ -9,13 +9,13 @@ export function useSectionTree(sectionId: number) {
 
   const q = useQuery({
     queryKey: qk.sectionTree(sectionId),
-    queryFn: () => fetchSectionTreeAndHydrate(qc, sectionId), // must return non-undefined (you did: `true`)
+    queryFn: () => fetchSectionTreeAndHydrate(qc, sectionId),
     enabled: Number.isFinite(sectionId),
-    staleTime: 0,
-    gcTime: 0,
-    retry: false, // avoid silent re-tries while wiring
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: false,
     refetchOnWindowFocus: false,
-    select: () => null, // we don’t use the payload
+    select: () => null,
   });
 
   return {

--- a/duoclone-root/duolingo-clone/src/util/scrollUtils.ts
+++ b/duoclone-root/duolingo-clone/src/util/scrollUtils.ts
@@ -1,0 +1,21 @@
+import type { RefObject } from "react";
+import type { UnitType } from "../Types/UnitType";
+
+export function scrollToUnit(
+  currentUnit: UnitType | null,
+  units: UnitType[] | undefined,
+  scrollContainerRef: RefObject<HTMLDivElement | null>,
+  unitRefs: RefObject<(HTMLElement | null)[]>
+) {
+  if (!currentUnit || !units || !scrollContainerRef || !scrollContainerRef.current) return;
+
+  const index = units.findIndex((unit) => unit.id === currentUnit.id);
+  if (index === -1 || !unitRefs.current?.[index]) return;
+
+  const element = unitRefs.current[index];
+  const container = scrollContainerRef.current;
+  if (!element) return;
+
+  const elementTop = element.offsetTop;
+  container.scrollTop = elementTop - container.clientHeight / 2;
+}


### PR DESCRIPTION
- Can now navigate between pages using footer
- Added a MainLayout wrapper for the routes so that the footer doesnt remount each time a page changes

- Cache scroll position on the section page so it does not need to recompute the page on revisit
- Start the user at the scroll position they left the section page at